### PR TITLE
Make satellite classification data-driven

### DIFF
--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -1,7 +1,6 @@
 import { selectEntity, lockOn } from "./handlers.js";
 import { initialise, createOrbitalEntity, getFormattedPosition, updateAllPositions } from "./satManager.js";
 import { state } from "./state.js";
-import { classificationColors, classifications, classifyFromTLE, colorFromClassification } from "./utils.js";
 
 // hides all the unnecessary stuff, note that we need to add a credits page for CesiumJS / providers later
 state.viewer = new Cesium.Viewer("cesiumContainer", {

--- a/app/static/js/satManager.js
+++ b/app/static/js/satManager.js
@@ -1,5 +1,5 @@
 import * as sat from "https://cdn.jsdelivr.net/npm/satellite.js@4.0.0/+esm";
-import { classifyFromTLE, colorFromClassification} from "./utils.js";
+import { classifyFromTLE } from "./utils.js";
 import { state } from "./state.js";
 const satjs = sat.default ?? sat;
 
@@ -45,7 +45,8 @@ export function createOrbitalEntity(name, position=undefined, satrec=undefined, 
     if (state.satellites.has(name)) {
         //update to default
         const satellite = state.satellites.get(name);
-        const color = colorFromClassification(satellite.satellite_object.properties.classification.getValue());
+        const classification = satellite.satellite_object.properties.classification.getValue()
+        const color = classification.color;
         satellite.satellite_object.point = {
                 pixelSize: 6,
                 color: color
@@ -68,7 +69,7 @@ export function createOrbitalEntity(name, position=undefined, satrec=undefined, 
 
         const classification = classifyFromTLE(name);
         
-        const color = colorFromClassification(classification);
+        const color = classification.color;
         const satellite_object = state.viewer.entities.add({
             position: position,
             point: {

--- a/app/static/js/utils.js
+++ b/app/static/js/utils.js
@@ -1,32 +1,62 @@
-export const classificationColors = {
-    StarLink: () => Cesium.Color.CYAN,
-    OneWeb: () => Cesium.Color.ORANGE,
-    Iridium: () => Cesium.Color.GREEN,
-    GPS: () => Cesium.Color.YELLOW,
-    unknown: () => Cesium.Color.GRAY
-};
+/**
+ * @typedef {Object} Classification
+ * @property {string} name
+ * @property {string[]} prefixes
+ * @property {number} color
+ * @property {boolean} [unknown]
+ */
 
-export const classifications = Object.freeze({
-    STARLINK: "StarLink",
-    ONEWEB: "OneWeb",
-    IRIDIUM: "Iridium",
-    GPS: "GPS",
-    UNKNOWN: "unknown"
-});
+/** @type {ReadonlyArray<Classification>} */
+const CLASSIFICATIONS = [
+    {
+        name: "Starlink",
+        prefixes: ["STARLINK"],
+        color: Cesium.Color.CYAN
+    },{
+        name: "OneWeb",
+        prefixes: ["ONEWEB", "OW-"],
+        color: Cesium.Color.ORANGE
+    },
+    {
+        name: "Iridium",
+        prefixes: ["IRIDIUM"],
+        color: Cesium.Color.GREEN
+    },
+    {
+        name: "GPS",
+        prefixes: ["GPS", "NAVSTAR"],
+        color: Cesium.Color.YELLOW
+    }
+]
 
-//used to decode TLE data to get classification
-//TODO #40 make this more robust using Inclination / Altitude / Mean motion data
-export function classifyFromTLE(tleName) {
-  const name = (tleName || "").toUpperCase().trim();
-
-  if (name.startsWith("STARLINK")) return classifications.STARLINK;
-  if (name.startsWith("ONEWEB") || name.startsWith("OW-")) return classifications.ONEWEB;
-  if (name.startsWith("IRIDIUM")) return classifications.IRIDIUM;
-  if (name.startsWith("GPS") || name.startsWith("NAVSTAR")) return classifications.GPS;
-
-  return classifications.UNKNOWN;
+/** @type {Classification} */
+const UNKNOWN_CLASSIFICATION = {
+    name: "Unknown",
+    prefixes: [],
+    color: Cesium.Color.GRAY,
+    unknown: true
 }
 
-export function colorFromClassification(classification) {
-    return classificationColors[classification]() ?? Cesium.Color.WHITE; 
+// Maps each possible prefix to its respective classification, including where there are multiple.
+const prefixToClassificationMap = CLASSIFICATIONS.flatMap(classification => 
+    classification.prefixes.map(prefix => [prefix, classification])
+).reduce((map, [prefix, classification]) => {
+    map[prefix] = classification
+    return map
+}, {})
+
+//used to decode TLE data to get classification
+//TODO #40 make this more robust using Inclination / Altitude / Mean motion data - can you explain this?
+/**
+ * @param {string} tleName
+ * @returns {Classification}
+ */
+export function classifyFromTLE(tleName = "") {
+  const name = tleName.toUpperCase().trim();
+
+  for (let prefix in prefixToClassificationMap) {
+    if (name.startsWith(prefix)) return prefixToClassificationMap[prefix]
+  }
+
+  return UNKNOWN_CLASSIFICATION;
 }


### PR DESCRIPTION
Makes satellite classification data-driven by using an array of classifications, which includes their color, prefixes and name.

This will make it easy to future proof features such as #53 and also make it easy to add more classifications by creating a new entry to this array.

Closes #70
